### PR TITLE
Remove the when, feedback, and before blocks in favor of more understandable "gates"

### DIFF
--- a/Otto.g4
+++ b/Otto.g4
@@ -129,11 +129,9 @@ stageStatements
     : steps
     | runtime
     | cache
-    | when
+    | gates
     | deployExpr
     | notify
-    | feedback
-    | before
     // And finally, allow nesting our stages!
     | stages+
     ;
@@ -158,19 +156,41 @@ cacheUseExpr
     ;
 
 runtime
-    : RUNTIME BEGIN 
+    : RUNTIME BEGIN
         (
         setting_block
         | fromExpr
         )
     END
     ;
-when
-    : WHEN BEGIN whenExpr* END
-    ;
-whenExpr
-    : (BRANCH EQUALS StringLiteral)
+/*
+ * XXX: This syntax requires some test coverage to ensure that the grammar
+ * allows for order independence properly, while still restricting only a
+ * single enter block, for example
+ */
+gates
+    : GATES BEGIN
+    (
+    enter
+    | exit
     | fromExpr
+    )+
+    END
+    ;
+enter
+    : ENTER BEGIN enterExpr+ END
+    ;
+exit
+    : EXIT BEGIN exitExpr+ END
+    ;
+enterExpr
+    : (BRANCH EQUALS StringLiteral)
+    | statements
+    | setting_block
+    ;
+exitExpr
+    : statements
+    | setting_block
     ;
 
 /*
@@ -192,19 +212,6 @@ notify
         END
         )+
     END
-    ;
-
-feedback
-    : FEEDBACK BEGIN
-        (
-        statements
-        | setting_block
-        )+
-    END
-    ;
-
-before
-    : BEFORE BEGIN statements+ END
     ;
 
 

--- a/Otto.g4
+++ b/Otto.g4
@@ -145,9 +145,18 @@ cache
         (
         (setting+)
         | fromExpr
+        | cacheUseExpr
         )
      END
     ;
+/*
+ * cache {} `use` expressions allow stages to pull in cached entries from
+ * elsewhere
+ */
+cacheUseExpr
+    : USE ID
+    ;
+
 runtime
     : RUNTIME BEGIN 
         (

--- a/OttoLexer.g4
+++ b/OttoLexer.g4
@@ -17,11 +17,9 @@ SUCCESS : 'success';
 FAILURE : 'failure';
 COMPLETE : 'complete';
 
-
-FEEDBACK : 'feedback';
-BEFORE : 'before';
-
-WHEN : 'when';
+GATES : 'gates';
+ENTER : 'enter';
+EXIT : 'exit';
 BRANCH : 'branch';
 EQUALS : '==';
 

--- a/examples/rubygem.blueprint
+++ b/examples/rubygem.blueprint
@@ -5,7 +5,7 @@
 
 
 use {
-  stdlib;
+  stdlib
 }
 
 blueprint {

--- a/examples/webapp.otto
+++ b/examples/webapp.otto
@@ -80,16 +80,36 @@ pipeline {
 
     stage('Deploy') {
       stage('Pre-production') {
-        when { branch == 'master' }
-
+        /*
+         * Indicate that the stage is going to interact with the preprod stage
+         * and the preprod environment settings must be made available to steps
+         */
         environment -> preprod
+
+        /*
+         * gates define the criteria for entering and exiting the stage.
+         */
+        gates {
+          enter {
+            branch == 'master'
+          }
+
+          /*
+           * The exit block is where external stimuli back into the system
+           * should be modeled, providing some means of holding back the pipeline
+           * until the condition has been met
+           */
+          exit {
+            input 'Does staging look good to you?'
+          }
+        }
 
         runtime {
           from 'Build'
         }
 
         cache {
-          from 'assets'
+          use assets
         }
 
         steps {
@@ -107,42 +127,36 @@ pipeline {
             slack 'Fire on warlock mountain!'
           }
         }
-
-        /*
-         * The feedback block is where external stimuli back into the system
-         * should be modeled, providing some means of holding back the pipeline
-         * until the feedback condition has been met
-         */
-        feedback {
-          input 'Does staging look good to you?'
-        }
       }
 
       stage('Production') {
-        when {
-          // Re-use our same conditions
+        gates {
           from 'Pre-production'
-        }
 
+          enter {
+            input 'Are you extra sure that staging looks good to you?'
+          }
+
+          exit {
+            /*
+            * Ideally the system has some form of tagging of this specific run,
+            * to allow an external system to call back and say "this is good and
+            * finished"
+            */
+            webhook {
+              description = 'Pingdom health check'
+            }
+          }
+
+        }
         environment -> production
-
-        /*
-         * Allow the starting of this stage based on some other condition.
-         *
-         * NOTE: it is unclear if this is useful, or confusing, but the
-         * use-case is to allow for some guarding logic before allocating the
-         * runtime environment for this stage.
-         */
-        before {
-          input 'Are you extra sure that staging looks good to you?'
-        }
 
         runtime {
           from 'Build'
         }
 
         cache {
-          from 'assets'
+          use assets
         }
 
         steps {
@@ -158,17 +172,6 @@ pipeline {
           }
           complete {
             slack 'New changes are live in production'
-          }
-        }
-
-        feedback {
-          /*
-           * Ideally the system has some form of tagging of this specific run,
-           * to allow an external system to call back and say "this is good and
-           * finished"
-           */
-          webhook {
-            description = 'Pingdom health check'
           }
         }
       }

--- a/examples/webapp.otto
+++ b/examples/webapp.otto
@@ -70,7 +70,7 @@ pipeline {
       }
 
       cache {
-        from 'gems'
+        use gems
       }
 
       steps {

--- a/services/parser/README.adoc
+++ b/services/parser/README.adoc
@@ -19,7 +19,6 @@ pipeline are as follows:
 * The path of execution must be numbered and trackable within the system. Other
   components will need to be able to refer back to the internal representation to
   determine where in the execution of the pipeline the process is currently.
-* Configuration data must be 
 
 === Example
 
@@ -48,6 +47,10 @@ pipeline {
         }
       }
 
+      cache {
+        gems = ['vendor/']
+      }
+
       steps {
         sh 'ruby --version'
       }
@@ -56,6 +59,9 @@ pipeline {
     stage('Test') {
       runtime {
         from 'Build'
+      }
+      cache {
+        use gems
       }
       steps {
         sh 'env'
@@ -102,6 +108,13 @@ stages:
       - type: 'sh'
         args:
           - 'ruby --version'
+    # `capture` and `restore` both would support archiving of artifacts and
+    # caching of files and directories between the different stages
+    capture:
+      gems:
+        - path: 'gems/'
+          type: 'directory'
+    restore:
   - name: 'Test'
     before:
     # Reference the stage by index
@@ -111,5 +124,8 @@ stages:
       - type: 'sh'
         args:
           - 'env'
+    capture:
+    restore:
+      - gems
 ----
 


### PR DESCRIPTION
This syntax makes it more clear the conditions not only that a stage can be
entered , but what conditions must be met in order for the stage to
exit/complete.

There's a slight nuance, which I am not certain at the moment is important with
'when' in the declarative Jenkins Pipeline syntax as it relates to 'enter' here.
The 'when' directive can be used to prevent a stage from being executed in a
flow, i.e. skipped. An "enter" however could mean "wait for this criteria to be met"
which might be confusing to a user, but I think this initial simplicity is worth
the experiment.

The "exit" is obviously a bit easier to understand, but where some nuance will
come later on is how we might determine/model what exit criteria should hold
onto cluster resources, versus a simple "listener" which requires no 'runtime'

---

This pull request also cleans up the `cache` syntax a bit, which didn't warrant its own pull request