### PR TITLE
Add grammar support for macros, which enable matrix use cases

### DIFF
--- a/Otto.g4
+++ b/Otto.g4
@@ -131,7 +131,7 @@ stageStatements
     | cache
     | gates
     | deployExpr
-    | notify
+    | notifyExpr
     | macro+
     // And finally, allow nesting our stages!
     | stages+
@@ -204,7 +204,7 @@ deployExpr
     ;
 
 
-notify
+notifyExpr
     : NOTIFY BEGIN
         (
         (SUCCESS | FAILURE | COMPLETE)

--- a/Otto.g4
+++ b/Otto.g4
@@ -101,7 +101,7 @@ settings
     : setting+
     ;
 setting
-    : ID ASSIGN (StringLiteral | array)
+    : ID ASSIGN (StringLiteral | array | macro | macroKeywords)
     ;
 array
     : ARRAY_START (StringLiteral COMMA?)+ ARRAY_END
@@ -118,7 +118,7 @@ pipeline_block
     ;
 
 stages_block
-    : STAGES BEGIN stages+ END
+    : STAGES BEGIN stages+ macro* END
     ;
 stages
     : STAGE BEGIN stageStatements* END
@@ -132,6 +132,7 @@ stageStatements
     | gates
     | deployExpr
     | notify
+    | macro+
     // And finally, allow nesting our stages!
     | stages+
     ;
@@ -239,6 +240,28 @@ statement
 step
     : ID StringLiteral
     ;
+
+
+/*
+ * Macro expressions can be a single line, or a single line with a block
+ * attached
+ */
+macro
+    : ID OPEN macroArguments CLOSE
+    (BEGIN (stages+)? END)?
+    ;
+macroArguments
+    :
+    (
+        (StringLiteral | macroKeywords)
+    COMMA?
+    )+
+    ;
+macroKeywords
+    : IT
+    ;
+
+
 
 /*
  * Keywords are expected to be semantically important after parse time and

--- a/Otto.g4
+++ b/Otto.g4
@@ -118,7 +118,7 @@ pipeline_block
     ;
 
 stages_block
-    : STAGES BEGIN stages+ macro* END
+    : STAGES BEGIN (macro? stages macro?)+ END
     ;
 stages
     : STAGE BEGIN stageStatements* END

--- a/Otto.g4
+++ b/Otto.g4
@@ -121,12 +121,12 @@ stages_block
     : STAGES BEGIN stages+ END
     ;
 stages
-    : STAGE OPEN StringLiteral CLOSE BEGIN stageStatements* END
+    : STAGE BEGIN stageStatements* END
     ;
 
-
 stageStatements
-    : steps
+    : settings
+    | steps
     | runtime
     | cache
     | gates

--- a/OttoLexer.g4
+++ b/OttoLexer.g4
@@ -45,6 +45,7 @@ ARRAY_END : ']';
 COMMA : ',';
 ASSIGN : '=';
 
+IT : 'it';
 
 StringLiteral: ('"' DoubleStringCharacter* '"'
              |  '\'' SingleStringCharacter* '\'')

--- a/examples/matrix.otto
+++ b/examples/matrix.otto
@@ -1,0 +1,59 @@
+/*
+ * This is a description of an Otto-managed continuous delivery process which
+ * requires a matrix of variables in order to operate correctly.
+ *
+ * This is a fairly common use-case where multiple platforms need to be
+ * supported or tested against.
+ */
+
+use {
+  stdlib
+}
+
+pipeline {
+  stages {
+
+    stage {
+      name = 'Build'
+
+      runtime {
+        docker { image = 'maven' }
+      }
+
+      steps {
+        sh 'mvn -B package'
+      }
+    }
+
+    each('win10', 'macos', 'linux-jdk12', 'linux-jdk8') {
+      /*
+       * The `it` keyword is semantically important and represents the
+       * different strings above when the `each` macro is expanded
+       *
+       */
+      stage {
+        name = concat('Test', it)
+        runtime {
+          computer { label = it }
+        }
+
+        steps {
+          sh 'mvn test'
+        }
+      }
+    }
+
+    stage {
+      name = 'Depoy'
+      runtime {
+        from 'Build'
+      }
+      steps {
+        sh 'mvn deploy'
+      }
+    }
+  }
+}
+
+
+// vim: ts=2 sw=2 et ai

--- a/examples/matrix.otto
+++ b/examples/matrix.otto
@@ -12,7 +12,6 @@ use {
 
 pipeline {
   stages {
-
     stage {
       name = 'Build'
 

--- a/examples/webapp.otto
+++ b/examples/webapp.otto
@@ -45,7 +45,9 @@ environments {
 
 pipeline {
   stages {
-    stage('Build') {
+    stage {
+      name = 'Build'
+
       runtime {
         docker {
           image = 'ruby'
@@ -64,7 +66,9 @@ pipeline {
       }
     }
 
-    stage('Test') {
+    stage {
+      name = 'Test'
+
       runtime {
         from 'Build'
       }
@@ -78,8 +82,11 @@ pipeline {
       }
     }
 
-    stage('Deploy') {
-      stage('Pre-production') {
+    stage {
+      name = 'Deploy'
+
+      stage {
+        name = 'Pre-production'
         /*
          * Indicate that the stage is going to interact with the preprod stage
          * and the preprod environment settings must be made available to steps
@@ -129,7 +136,10 @@ pipeline {
         }
       }
 
-      stage('Production') {
+      stage {
+        name = 'Production'
+        environment -> production
+
         gates {
           from 'Pre-production'
 
@@ -149,7 +159,6 @@ pipeline {
           }
 
         }
-        environment -> production
 
         runtime {
           from 'Build'

--- a/parse-test.js
+++ b/parse-test.js
@@ -5,14 +5,6 @@ const Lexer = require('./build/parser/JavaScript/OttoLexer').OttoLexer;
 const Parser = require('./build/parser/JavaScript/Otto').Otto;
 const OttoListener = require('./build/parser/JavaScript/OttoListener').OttoListener;
 
-const input = fs.readFileSync('./examples/webapp.otto', 'utf8');
-let chars = new antlr.InputStream(input);
-let lexer = new Lexer(chars);
-let tokens = new antlr.CommonTokenStream(lexer);
-let parser = new Parser(tokens);
-parser.buildParseTrees = true;
-let tree = parser.pipeline();
-
 class Visitor {
   visitChildren(ctx) {
     if (!ctx) {
@@ -46,5 +38,18 @@ class L extends OttoListener {
   }
 }
 
-//tree.accept(new Visitor());
-antlr.tree.ParseTreeWalker.DEFAULT.walk(new L(), tree);
+[
+  './examples/webapp.otto',
+  './examples/matrix.otto',
+].map((filename) => {
+  console.log(`Processing ${filename}`);
+  const input = fs.readFileSync(filename, 'utf8');
+  let chars = new antlr.InputStream(input);
+  let lexer = new Lexer(chars);
+  let tokens = new antlr.CommonTokenStream(lexer);
+  let parser = new Parser(tokens);
+  parser.buildParseTrees = true;
+  let tree = parser.pipeline();
+  //tree.accept(new Visitor());
+  antlr.tree.ParseTreeWalker.DEFAULT.walk(new L(), tree);
+});

--- a/services/parser/README.adoc
+++ b/services/parser/README.adoc
@@ -40,7 +40,8 @@ configure {
 
 pipeline {
   stages {
-    stage('Build') {
+    stage {
+      name = 'Build'
       runtime {
         docker {
           image = 'ruby:latest'
@@ -56,7 +57,8 @@ pipeline {
       }
     }
 
-    stage('Test') {
+    stage {
+      name = 'Test'
       runtime {
         from 'Build'
       }


### PR DESCRIPTION
This pull request builds on top of #3, and introduces support for "macros" which are intended to generate new snippets of otto declarations. In the example, `each` and `concat` are introduced to make a simple matrix use case work properly

Right now this is intended to be parsed and then the compile can figure it out, but in the future I might just separate the macros into their own parser and run that as a first pass on the `.otto` file before feeding the pre-processed buffer into the main `.otto` parser.

The other notable change in this pull request is the conversion from `stage('Build') {}` to `stage { name = 'Build' }` which allows _only_ macros to look like `symbol()` and brings the stage block into alignment with all the other blocks.