### PR TITLE
WIP: Implementing the parse listener

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "name": "jest",
+            "request": "launch",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": [
+                "--runInBand"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/index.js"
+        }
+    ]
+}

--- a/grammar/Otto.g4
+++ b/grammar/Otto.g4
@@ -118,9 +118,9 @@ pipeline_block
     ;
 
 stages_block
-    : STAGES BEGIN (macro? stages macro?)+ END
+    : STAGES BEGIN (macro? stage macro?)+ END
     ;
-stages
+stage
     : STAGE BEGIN stageStatements* END
     ;
 
@@ -134,7 +134,7 @@ stageStatements
     | notifyExpr
     | macro+
     // And finally, allow nesting our stages!
-    | stages+
+    | stage+
     ;
 steps
     : STEPS BEGIN statements+ END
@@ -248,7 +248,7 @@ step
  */
 macro
     : ID OPEN macroArguments CLOSE
-    (BEGIN (stages+)? END)?
+    (BEGIN (stage+)? END)?
     ;
 macroArguments
     :

--- a/services/parser/__tests__/Orf.ts
+++ b/services/parser/__tests__/Orf.ts
@@ -1,14 +1,28 @@
 
-import Orf from '../src/Orf'
+import { Orf } from '../src/Orf'
 
 describe('Orf', () => {
-  it('should instantiate', () => {
-    expect(new Orf()).toBeTruthy()
-  })
-
   it('should have a version', () => {
     expect((new Orf()).version).toBeGreaterThan(0)
   })
+
+  describe('handling libraries', () => {
+    describe('.libraries', () => {
+      it('should return an empty array by default', () => {
+        const o = new Orf()
+        expect(o.libraries).toHaveLength(0)
+      })
+    })
+  });
+
+  describe('handling runtimes', () => {
+    describe('.runtimes', () => {
+      it('should return an empty array by default', () => {
+        const o = new Orf()
+        expect(o.runtimes).toHaveLength(0)
+      })
+    });
+  });
 
   describe('when serialized', () => {
     it('should serialize by default', () => {

--- a/services/parser/__tests__/ParseListener.ts
+++ b/services/parser/__tests__/ParseListener.ts
@@ -2,7 +2,7 @@ import antlr from 'antlr4'
 
 import ParseListener from '@otto-parser/ParseListener'
 
-import { Otto } from '@otto/grammar/Otto'
+import * as otto from '@otto/grammar/Otto'
 import { OttoLexer } from '@otto/grammar/OttoLexer'
 import { OttoListener } from '@otto/grammar/OttoListener'
 
@@ -12,7 +12,7 @@ function walkTreeFor(listener: ParseListener, input: string) {
   let chars = new antlr.InputStream(input)
   let lexer = new OttoLexer(chars)
   let tokens = new antlr.CommonTokenStream(lexer)
-  let parser = new Otto(tokens)
+  let parser = new otto.Otto(tokens)
   parser.buildParseTrees = true
   let tree = parser.pipeline()
   antlr.tree.ParseTreeWalker.DEFAULT.walk(listener, tree)
@@ -57,5 +57,10 @@ describe('ParseListener', () => {
       const orf = parsedOrf()
       expect(orf).not.toStrictEqual(EMPTY_ORF)
     });
+
+    it('the orf should have a single runtime', () => {
+      const orf = parsedOrf()
+      expect(orf.runtimes.length).toEqual(1)
+    })
   });
 })

--- a/services/parser/__tests__/ParseListener.ts
+++ b/services/parser/__tests__/ParseListener.ts
@@ -61,6 +61,13 @@ describe('ParseListener', () => {
     it('the orf should have a single runtime', () => {
       const orf = parsedOrf()
       expect(orf.runtimes.length).toEqual(1)
+      expect(orf.runtimes[0].runtimeType).toEqual('docker')
+    })
+
+    it('should parse out the stages', () => {
+      const orf = parsedOrf()
+      expect(orf.stages.length).toEqual(1)
+      expect(orf.stages[0].name).toEqual('Build')
     })
   });
 })

--- a/services/parser/src/FileCapture.ts
+++ b/services/parser/src/FileCapture.ts
@@ -1,0 +1,3 @@
+
+export default interface FileCapture {
+}

--- a/services/parser/src/Orf.ts
+++ b/services/parser/src/Orf.ts
@@ -5,6 +5,9 @@
  * See the parser README for more information
  */
 
+ import Runtime from '@otto-parser/Runtime'
+
+
 // tslint:disable:max-classes-per-file
 enum LibraryType {
   Builtin,
@@ -23,9 +26,6 @@ class Setting {
 
 class Configuration {
   protected readonly settings: Map<string, Setting>
-}
-
-interface Runtime {
 }
 
 interface Step {

--- a/services/parser/src/Orf.ts
+++ b/services/parser/src/Orf.ts
@@ -48,13 +48,13 @@ class Stage {
  * Orf is the Otto Representation Format and acts as the parsed and serialized
  * format of a .otto file, suitable for consumption by components within Otto.
  */
-export default class Orf {
+export class Orf {
   /** The version field is for system compatibility */
   public readonly version = 1
   /**
    * An array of libraries which must be loaded at runtime
    */
-  protected libraries: Library[] = []
+  protected _libraries: Library[] = []
 
   /**
    * A map of configuration objects for configuring arbitrary
@@ -65,7 +65,7 @@ export default class Orf {
   /**
    * An ordered array of runtimes which will be used throughout the process
    */
-  protected runtimes: Runtime[] = []
+  protected _runtimes: Runtime[] = []
 
   /**
    * An ordered array of stages as they have been parsed, not necessary how
@@ -73,7 +73,43 @@ export default class Orf {
    */
   protected stages: Stage[] = []
 
+  /**
+   * Default constructor for the Orf
+   *
+   * This doesn't do anything substantial except allocate the collections the
+   * Orf needs to hold onto.
+   */
   constructor() {
     this.configuration = new Map<string, Configuration>()
   }
+
+  get libraries() {
+    return this._libraries
+  }
+
+  /**
+   * Add the given library to the Orf
+   *
+   * @return Boolean true if the addition was successful
+   */
+  public addLibrary(lib: Library): Boolean {
+    this._libraries.push(lib)
+    return true
+  }
+
+  get runtimes() {
+    return this._runtimes
+  }
+
+  /**
+   * Add the given runtime to the Orf
+   *
+   * @return Boolean true if the addition was successful
+   */
+  public addRuntime(runtime: Runtime): Boolean {
+    this._runtimes.push(runtime)
+    return false
+  }
 }
+
+export const EMPTY_ORF = new Orf()

--- a/services/parser/src/Orf.ts
+++ b/services/parser/src/Orf.ts
@@ -5,7 +5,8 @@
  * See the parser README for more information
  */
 
- import Runtime from '@otto-parser/Runtime'
+import Runtime from '@otto-parser/Runtime'
+import Stage from '@otto-parser/Stage'
 
 
 // tslint:disable:max-classes-per-file
@@ -26,22 +27,6 @@ class Setting {
 
 class Configuration {
   protected readonly settings: Map<string, Setting>
-}
-
-interface Step {
-}
-
-interface FileCapture {
-}
-
-class Stage {
-  protected readonly name: string
-  protected before: Stage
-  protected after: Stage
-  protected runtime: Runtime
-  protected steps: Step[] = []
-  protected capture: Map<string, FileCapture>
-  protected restore: String[]
 }
 
 /**
@@ -71,7 +56,7 @@ export class Orf {
    * An ordered array of stages as they have been parsed, not necessary how
    * they will be executed which may be more of a directed graph.
    */
-  protected stages: Stage[] = []
+  protected _stages: Stage[] = []
 
   /**
    * Default constructor for the Orf
@@ -108,7 +93,15 @@ export class Orf {
    */
   public addRuntime(runtime: Runtime): Boolean {
     this._runtimes.push(runtime)
-    return false
+    return true
+  }
+
+  get stages() {
+    return this._stages
+  }
+  public addStage(stage: Stage) {
+    this._stages.push(stage)
+    return true
   }
 }
 

--- a/services/parser/src/ParseListener.ts
+++ b/services/parser/src/ParseListener.ts
@@ -1,7 +1,7 @@
 /*
  * The ParseListener is the initial entrypoint for building the graph
  */
-import { Otto } from '@otto/grammar/Otto'
+import * as otto from '@otto/grammar/Otto'
 import { OttoLexer } from '@otto/grammar/OttoLexer'
 import { OttoListener } from '@otto/grammar/OttoListener'
 import logger from '@otto/logger'
@@ -15,6 +15,7 @@ export default class ParseListener extends OttoListener {
    */
   protected readonly orf: Orf
   protected completed: Boolean = false
+  protected runtimes = []
 
   constructor() {
     super()
@@ -23,6 +24,26 @@ export default class ParseListener extends OttoListener {
 
   public enterStages(ctx) {
     logger.debug('Parsing stage at line %s:%s', ctx.start.line, ctx.start.column)
+  }
+
+  /**
+   * Return true if the node name is not a terminal
+   */
+  private withoutTerminals(node) {
+    return node.constructor.name != 'TerminalNodeImpl'
+  }
+
+  public exitRuntime(ctx) {
+    logger.debug('exiting runtime',)
+    ctx.children
+      .filter(c => this.withoutTerminals(c))
+      .forEach((child) => {
+      console.log(child.constructor.name)
+      console.log(Object.getPrototypeOf(child))
+
+      child.children.filter(c => this.withoutTerminals(c))
+        .forEach(nc => console.log(Object.getPrototypeOf(nc)))
+    })
   }
 
   public exitPipeline(ctx) {

--- a/services/parser/src/ParseListener.ts
+++ b/services/parser/src/ParseListener.ts
@@ -4,6 +4,40 @@
 import { Otto } from '@otto/grammar/Otto'
 import { OttoLexer } from '@otto/grammar/OttoLexer'
 import { OttoListener } from '@otto/grammar/OttoListener'
+import logger from '@otto/logger'
+
+import { Orf, EMPTY_ORF } from '@otto-parser/Orf'
 
 export default class ParseListener extends OttoListener {
+  /**
+   * The orf is generated per instance of the ParseListener, which means that
+   * the object should not be re-used for multiple parse runs
+   */
+  protected readonly orf: Orf
+  protected completed: Boolean = false
+
+  constructor() {
+    super()
+    this.orf = new Orf()
+  }
+
+  public enterStages(ctx) {
+    logger.debug('Parsing stage at line %s:%s', ctx.start.line, ctx.start.column)
+  }
+
+  public exitPipeline(ctx) {
+    logger.debug('Exiting pipeline at line %s:%s', ctx.start.line, ctx.start.column)
+    this.completed = true
+  }
+
+  /**
+   * Return the computed orf only if the processing has been completed,
+   * otherwise a null will be returned
+   */
+  public getOrf(): Orf {
+    if (this.completed) {
+      return this.orf
+    }
+    return EMPTY_ORF
+  }
 }

--- a/services/parser/src/Runtime.ts
+++ b/services/parser/src/Runtime.ts
@@ -1,0 +1,13 @@
+/*
+ *
+ */
+export default class Runtime {
+  public readonly runtimeType: string
+  public readonly settings: Object
+
+
+  constructor(t: string, settings: Object) {
+    this.runtimeType = t
+    this.settings = settings
+  }
+}

--- a/services/parser/src/Stage.ts
+++ b/services/parser/src/Stage.ts
@@ -1,0 +1,13 @@
+import Runtime from '@otto-parser/Runtime'
+import Step from '@otto-parser/Step'
+import FileCapture from '@otto-parser/FileCapture'
+
+export default class Stage {
+  public name: string
+  protected before: Stage
+  protected after: Stage
+  public runtime: Runtime
+  protected steps: Step[] = []
+  protected capture: Map<string, FileCapture>
+  protected restore: String[]
+}

--- a/services/parser/src/Step.ts
+++ b/services/parser/src/Step.ts
@@ -1,0 +1,3 @@
+
+export default interface Step {
+}


### PR DESCRIPTION
This pull request is a work in progress.

These changes implement an ANTLR4 parse tree listener which will allow converting a `.otto` file into an "`Orf`" (Otto Representation Format), which can be used internally for execution of the pipeline