### PR TITLE
Add multi-line comment support to parser

### DIFF
--- a/Ottofile
+++ b/Ottofile
@@ -1,3 +1,6 @@
+/*
+ Example Ottofile
+*/
 
 pipeline {
   steps {

--- a/crates/parser/src/pipeline.pest
+++ b/crates/parser/src/pipeline.pest
@@ -44,4 +44,5 @@ STRV = @{ "''" | (!"'" ~ ANY)* }
 COMMA = @{ "," }
 
 WHITESPACE = _{ (" " | NEWLINE) }
-COMMENT = _{ "//" ~ (!NEWLINE ~ ANY)* }
+BLOCK_COMMENT = _{ "/*" ~ (BLOCK_COMMENT | !"*/" ~ ANY)* ~ "*/" }
+COMMENT    = _{ BLOCK_COMMENT | ("//" ~ (!NEWLINE ~ ANY)*) }


### PR DESCRIPTION
Copied this straight from Pest itself so must be right 😅
https://github.com/pest-parser/pest/pull/332/files

Tested against
```
/* 1-line multiline comment */

/*
  N-line multiline comment
*/

/*
  // Line comment inside multiline
  /*
    (Multiline inside) multiline
  */

*/
```

Testing steps -
* `cargo build`
* `make run`
* `scripts/local-run` with above inputs

Fixes #57 